### PR TITLE
stream mysqldump through 'sed'

### DIFF
--- a/create.sh
+++ b/create.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-# how this was created
-mysqldump -u io500committee --no-create-info --extended-insert --single-transaction -p -h mysql.io500.org io500_db > data.sql
-# break lines to format it better
-sed "s/),/),\n/g" data.sql > dump.sql
-
-
+# dump the database into plain text so that it can be reviewed more easily
+# split output with one record per line so that it is human-readable in Git
+mysqldump -u io500committee --no-create-info --extended-insert --single-transaction -p -h mysql.io500.org io500_db | sed "s/),/),\n/g" > data.sql


### PR DESCRIPTION
Using a file for both the input and redirected ('>') output may result in the file
being truncated before it is read.  Instead, use "sed" as intended, as a stream
editor, before anything is written to the output file.